### PR TITLE
Update GFortran.sublime-build

### DIFF
--- a/build-systems/GFortran.sublime-build
+++ b/build-systems/GFortran.sublime-build
@@ -4,6 +4,7 @@
 	"working_dir": "${file_path}",
 	"selector": "source.modern-fortran, source.fixedform-fortran",
 	"syntax": "GFortranBuild.sublime-syntax",
+	"shell": true,
 	"windows": {
 		"cmd": ["gfortran", "${file}", "-o", "${file_base_name}.exe"]
 	},


### PR DESCRIPTION
Shell is needed when using batch wrapper.

 Example `gfortran.cmd` wrapper:

``` batch
@echo off
set PATH=D:\mingw-w64\mingw64\bin;%PATH%
gfortran %*
```
